### PR TITLE
Problem when binding options if the currentValue is an int 

### DIFF
--- a/backbone.epoxy.js
+++ b/backbone.epoxy.js
@@ -700,7 +700,17 @@
 				var optionsEmpty = readAccessor( self.e );
 				var optionsDefault = readAccessor( self.d );
 				var currentValue = readAccessor( self.v );
-				var selection = isArray(currentValue) ? currentValue : [ currentValue ];
+
+                //currentValue should work in the same way if its a number or a string
+                if (isArray(currentValue)){
+                    _.each(currentValue, function( value, index ) {
+                        currentValue[index] = value.toString();
+                    });
+                }else {
+                    currentValue = currentValue != null ? currentValue.toString(): null;
+                }
+
+                var selection = isArray(currentValue) ? currentValue : [ currentValue ];
 				var options = isCollection( value ) ? value.models : value;
 				var numOptions = options.length;
 				var enabled = true;

--- a/test/epoxy-test.js
+++ b/test/epoxy-test.js
@@ -373,11 +373,11 @@ describe("Backbone.Epoxy.View", function() {
 			lastName: "Skywalker",
 			preference: "b",
 			active: true,
-			valOptions: "1",
-			valDefault: "1",
-			valEmpty: "1",
-			valBoth: "1",
-			valMulti: "1",
+			valOptions: 1,
+			valDefault: 1,
+			valEmpty: 1,
+			valBoth: 1,
+			valMulti: 1,
 			valCollect: ""
 		},
 		


### PR DESCRIPTION
In my opinion it should work in the same way if it's an integer or a string.
