### PR TITLE
Allow a reset on a collection binding to remove views

### DIFF
--- a/backbone.epoxy.js
+++ b/backbone.epoxy.js
@@ -618,8 +618,8 @@
 					
 					// SORT/RESET Event (from a Collection):
 					// First test if we're sorting...
-					// (we have models and all their views are present)
-					var sort = models.length && collection.every(function(model) {
+					// (we have models and the number of models hasn't changed and all their views are present)
+					var sort = models.length && (_.keys(views).length == models.length) && collection.every(function(model) {
 						return views.hasOwnProperty(model.cid);
 					});
 					


### PR DESCRIPTION
This is a bit of an edge case, but I had a case where it wasn't practical to add/remove models from the collection as the logic for managing the collection members was on the server. As a result, my resetting the collection wasn't removing views correctly. This patch catches that gotcha, and shouldn't introduce any unnecessary full view resets.

Previously, a reset event on a collection would never remove views. For example:

```
users = new Backbone.Collection([{ name: 'nfm' }])
// Render a view with a collection binding to users
users.reset([])
// The exising view for the user nfm will not be removed
```

This commit ensures that not only is there a view for each model, but also that the number of models has not changed (it can only have decreased if the `collection.every()` call returns true). If it has, we go through the process of resetting with new views.
