### PR TITLE
Setters on computed view properties were never invoked if the new value evaluated as falsy

### DIFF
--- a/backbone.epoxy.js
+++ b/backbone.epoxy.js
@@ -1007,7 +1007,7 @@
 				getter.id = name;
 				
 				context[ name ] = function(value) {
-					return (value && setter) ?
+					return (!isUndefined(value) && setter) ?
 						setter.call(self, value) :
 						getter.apply(self, getDepsFromViewContext(self._c, deps));
 				};


### PR DESCRIPTION
This caused problems with UI elements like checkboxes that were bound to a computed view property.  The setter would be invoked when the checkbox was switched on, but when it was switched off, the setter function got skipped.
