### PR TITLE
Fix for odd browserify behaviour

### DIFF
--- a/backbone.epoxy.js
+++ b/backbone.epoxy.js
@@ -7,15 +7,13 @@
 
 (function(root, factory) {
 	
-	var backbone = 'backbone';
-	var underscore = 'underscore';
 	
 	if (typeof exports !== 'undefined') {
 		// Define as CommonJS export:
-		module.exports = factory(require(underscore), require(backbone));
+		module.exports = factory(require("underscore"), require("backbone"));
 	} else if (typeof define === 'function' && define.amd) {
 		// Define as AMD:
-		define([underscore, backbone], factory);
+		define(["underscore", "backbone"], factory);
 	} else {
 		// Just run it:
 		factory(root._, root.Backbone);


### PR DESCRIPTION
Browserify is currently not compatible with backbone-epoxy as it appears it does not support resolving require(package) calls where package is a variable containing a string versus an actual string. E.g.

``` js
var underscore = "underscore";
var _ = require(underscore)
```

Does not work. However:

``` js
var _ = require("underscore")
```

works as expected. In the former example, browserify complains it cannot find the package. I believe browserify must be doing some strange parsing of the JS files in order to acertain where require() calls are so it can compile a single file.

The very simple solution is to just use strings (most if not all libraries I've seen do this).
