### PR TITLE
Prevent Google Closure Compiler from taking a shortcut

### DIFF
--- a/backbone.epoxy.js
+++ b/backbone.epoxy.js
@@ -1153,7 +1153,7 @@
 			
 			// Set Object (non-null, non-array) hashtable value:
 			if (!isObject(value) || isArray(value)) {
-				var val = value;
+				var val = _.clone(value);
 				(value = {})[attribute] = val;
 			}
 			


### PR DESCRIPTION
Google Closure Compiler and perhaps other minifiers would re-write this as:
(value = {})[attribute] = value, which will lead to recursive referencing.
