### PR TITLE
Use return-functions for bindingSources example

### DIFF
--- a/www/documentation.html
+++ b/www/documentation.html
@@ -547,9 +547,9 @@ var BindingView = Backbone.Epoxy.View.extend({
     model: new Backbone.Model({name: "Luke Skywalker"}),
     collection: new Backbone.Collection(),
     bindingSources: {
-        han: new Backbone.Model({name: "Han Solo"}),
-        obiwan: new Backbone.Model({name: "Obi-Wan Kenobi"}),
-        users: new Backbone.Collection()
+        han: function() { return new Backbone.Model({name: "Han Solo"}) },
+        obiwan: function() { return new Backbone.Model({name: "Obi-Wan Kenobi"}) },
+        users: function() { new Backbone.Collection() }
     }
 });
 


### PR DESCRIPTION
Many users will not easily understand that if you don't do this, the bindingSources will be global models. Then, while creating multiple instances of the same view the models will be shared which will lead to issues. The return-functions prevent this.
