### PR TITLE
Select options binding: set sometimes reverts to default value

### DIFF
--- a/backbone.epoxy.js
+++ b/backbone.epoxy.js
@@ -730,7 +730,7 @@
 				}
 
 				// Set new HTML to the element and toggle disabled status:
-				$element.html(html).prop('disabled', !enabled);
+				$element.html(html).prop('disabled', !enabled).val(currentValue);
 
 				// Pull revised value with new options selection state:
 				var revisedValue = $element.val();


### PR DESCRIPTION
It seems that the html replace doesn't always do the right thing or the
value binding runs to soon. This fix ensures that we try to set the
value we want and if we can't it will set the default value.
