### PR TITLE
Allow the Epoxy.View to be mixed in with out eliminating bindings

### DIFF
--- a/backbone.epoxy.js
+++ b/backbone.epoxy.js
@@ -42,7 +42,7 @@
 			extend = extend || {};
 
 			for (var i in this.prototype) {
-				if (this.prototype.hasOwnProperty(i) && i !== 'constructor') {
+				if (this.prototype.hasOwnProperty(i) && i !== 'constructor' && i !== 'bindings' ) {
 					extend[i] = this.prototype[i];
 				}
 			}


### PR DESCRIPTION
It's nice to be able to just call  Epoxy.View.mixin(this); instead of trying to create a mixed in hiearchy of views. It works great except that the bindings get wiped out (if you aren't using data-bind).

This small change causes the bindings to not be replaced.
