### PR TITLE
HTML5 contenteditable support in `text` bindings

### DIFF
--- a/backbone.epoxy.js
+++ b/backbone.epoxy.js
@@ -812,9 +812,14 @@
 			}
 		}),
 
-		// Text: write-only. Sets the text value of an element.
-		text: makeHandler(function($element, value) {
-			$element.text(value);
+		// Text: read-write. Gets and sets the text value of an element.
+		text: makeHandler({
+			get: function($element) {
+				return $element.text();
+			},
+			set: function($element, value) {
+				$element.text(value);
+			}
 		}),
 
 		// Toggle: write-only. Toggles the visibility of an element.

--- a/www/documentation.html
+++ b/www/documentation.html
@@ -926,9 +926,15 @@ var view = new ListView();</code></pre>
 			
 			<div class="section">
 				<h3 id="handler-text">text</h3>
-				<span class="alias">read-only</span>
+				<span class="alias">read-write</span>
 				<code>data-bind="text:modelAttribute"</code>
 				<p>Sets the element's text content to the bound model attribute value. Uses the jQuery <b>text</b> method.</p>
+
+				<p>To enable a writeable binding, add the HTML5 <tt>contenteditable</tt> property to the element:</p>
+
+<pre><code class="html">&lt;span contenteditable="true" data-bind="text:yourName,events:['blur paste']"&gt;
+    Select to edit your name.
+&lt;/span&gt;</code></pre>
 			</div>
 			
 			<div class="section">


### PR DESCRIPTION
This was touched upon in #15, but the behavior was only enabled for the `value` binding handler.  The PR adds support for `text` bindings and adjusts the documentation to demonstrate usage.
