### PR TITLE
Allow checked binding handler to handle grouped elements

### DIFF
--- a/backbone.epoxy.js
+++ b/backbone.epoxy.js
@@ -556,7 +556,11 @@
 
     // Checked: read-write. Toggles the checked status of a form element.
     checked: makeHandler({
-      get: function($element, currentValue) {
+      get: function($element, currentValue, event) {
+        if ($element.length > 1) {
+          $element = $(event.target);
+        }
+
         var checked = !!$element.prop('checked');
         var value = $element.val();
 
@@ -582,6 +586,15 @@
       set: function($element, value) {
         // Default as loosely-typed boolean:
         var checked = !!value;
+        
+        // If $element matches multiple DOM element then
+        // only set the element whose value matches
+        if ($element.length > 1) {
+          if (($element = $element.filter('[value=' + value + ']')).length === 0) {
+            //No element has the specified value so don't change anything
+            return;
+          }
+        }
 
         if (this.isRadio($element)) {
           // Radio button: match checked state to radio value.


### PR DESCRIPTION
If the DOM selector for an input matches multiple elements, eg input[name="gender"], then the checked binding handler would be provided an array of elements but would only operate on the first element within the array. In the case of setting the value, we only need to set the value of the matched element. For getting the value, we can rely on the target of the event to specify with which element was interacted.

Fixes #77 