### PR TITLE
Fixed integration with backbone-relational plugin

### DIFF
--- a/backbone.epoxy.js
+++ b/backbone.epoxy.js
@@ -1178,7 +1178,8 @@
       };
 
       // Compile all model attributes as accessors within the context:
-      _.each(source.toJSON({computed:true}), function(value, attribute) {
+      var modelAttributes = _.extend({}, source.attributes, _.isFunction(source.c) ? source.c() : {});
+      _.each(modelAttributes, function(value, attribute) {
 
         // Create named accessor functions:
         // -> Attributes from 'view.model' use their normal names.


### PR DESCRIPTION
Backbone-relational can define the way how to serialize model into JSON using relations. 
So by using method "toJSON" instead of accessing attributes property it's impossible to access some relations (e.g. if relation has includeInJSON : 'id').