### PR TITLE
:checked handler doesn't raise error when value is blank

### DIFF
--- a/backbone.epoxy.js
+++ b/backbone.epoxy.js
@@ -587,6 +587,10 @@
         if ($element.length > 1) {
           $element = $element.filter('[value="'+ value +'"]');
         }
+
+        if ($element.length < 1) {
+          return $element;
+        }
         
         // Default as loosely-typed boolean:
         var checked = !!value;


### PR DESCRIPTION
When there is no value for a model, and no checkbox is checked on page load, this checked handler throws an error.

Making a change to bail out instead of trying to set the value if there is no matching radio to set. I tried to get a spec written for this but running `grunt test` yielded an error: 

```running "mocha_phantomjs:all" (mocha_phantomjs) task
Test
Failed to start mocha: Init timeout
Unsafe JavaScript attempt to access frame with URL about:blank from frame with URL file:///Users/mike/code/backbone.epoxy/node_modules/grunt-mocha-phantomjs/node_modules/mocha-phantomjs/lib/mocha-phantomjs.coffee. Domains, protocols and ports must match.```

Not sure how up to date your tests are, but I didn't want to monkey with that.