### PR TITLE
Issue #130: Properties with dashes in their names

### DIFF
--- a/backbone.epoxy.js
+++ b/backbone.epoxy.js
@@ -1267,6 +1267,9 @@
         var pairs = declarations.split(/,((?=[^\]]*(?:\[|$))+(?=[^\}]*(?:\{|$)))/);
         pairs.forEach(function(item) {
           var value = "";
+          if (item.trim().length === 0) {
+            return;
+          }
           var split = item.split(":");
           if (split.length < 2) {
             throw new Error("Declaration is in an invalid format");

--- a/backbone.epoxy.js
+++ b/backbone.epoxy.js
@@ -1264,7 +1264,7 @@
     try {
       var parserFunct = bindingCache[declarations] || (bindingCache[declarations] = function($f, $c, declarations) {
         var result = {};
-        var pairs = declarations.split(/,(?=[^\]]*(?:\[|$))/);
+        var pairs = declarations.split(/,((?=[^\]]*(?:\[|$))+(?=[^\}]*(?:\{|$)))/);
         pairs.forEach(function(item) {
           var value = "";
           var split = item.split(":");


### PR DESCRIPTION
Everything appears to work as it did previously, but this modification now handles the use case where the declarations variable could have a dash in it (EX: "value:background-color"). Additionally the declarations variable is passed into the function, to ensure it's defined.

This pull request includes the type conversion that happened automatically by creating a function using the function constructor.
