### PR TITLE
Bumping grunt-contrib-uglify to resolve build failures

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,12 +30,12 @@
     "jquery": ">=1.11.0"
   },
   "devDependencies": {
+    "chai": "~1.8.1",
     "grunt": "~0.4.1",
-    "grunt-contrib-uglify": "~0.1.2",
+    "grunt-contrib-uglify": "^2.0.0",
     "grunt-mocha-phantomjs": "^0.5.0",
     "mocha": "~1.17.0",
-    "phantomjs": "^1.9.1",
-    "chai": "~1.8.1"
+    "phantomjs": "^1.9.1"
   },
   "jam": {
     "dependencies": {


### PR DESCRIPTION
Resolving the following.

> Warning: Cannot assign to read only property 'subarray'