### PR TITLE
Expose modelMap

### DIFF
--- a/backbone.epoxy.js
+++ b/backbone.epoxy.js
@@ -60,7 +60,6 @@
 
   // Epoxy.Model
   // -----------
-  var modelMap;
   var modelProps = ['computeds'];
 
   Epoxy.Model = Backbone.Model.extend({
@@ -87,7 +86,7 @@
     get: function(attribute) {
 
       // Automatically register bindings while building out computed dependency graphs:
-      modelMap && modelMap.push(['change:'+attribute, this]);
+      Epoxy.modelMap && Epoxy.modelMap.push(['change:'+attribute, this]);
 
       // Return a computed property value, if available:
       if (this.hasComputed(attribute)) {
@@ -410,9 +409,9 @@
       // All Epoxy.Model attributes accessed while getting the initial value
       // will automatically register themselves within the model bindings map.
       var bindings = {};
-      var deps = modelMap = [];
+      var deps = Epoxy.modelMap = [];
       this.get(true);
-      modelMap = null;
+      Epoxy.modelMap = null;
 
       // If the computed has dependencies, then proceed to binding it:
       if (deps.length) {


### PR DESCRIPTION
When a model has computed properties, it's only possible to specify dependencies that are attributes to that model. However, I have a case where it would be useful to do something like this:
```javascript
var Model = Epoxy.Model.extend({
  "computeds": {
    "b": {
      "deps": ['model:a'],
      get: function(a) {
        return 2*a;
      }
    }
  }
});
var sub = new Epoxy.Model({
  "a": 1
});
var main = new Model({
  "model": sub
});

// true
main.get('b') === 2;
```
It can be more or less compared to the concept of binding sources with Views.

I don't think that this should be integrated into Epoxy itself, but I found out that it's easy to implement this myself if the modelMap that Epoxy uses to define dependencies for computed properties was exposed. Right now this is a private variable in the Epoxy library which can't be accessed from outside the library. If it was possible to access it - for example as Epoxy.modelMap - I could implement the functionality described above by overriding the get method as
```javascript
var Model = Epoxy.Model.extend({
  get: function(attr) {
    var match;
    // Detect model.get('submodel:attr');
    if (match = attr.match(/([^:]*):(.*)/)) {
      var sub = this.get(match[1]);
      return sub.get(match[2]);
    }
    Epoxy.modelMap && Epoxy.modelMap.push(['change'+attr, this]);
    if (this.hasComputed(attr)) {
      return this.c()[ attr ].get();
    }
    return Epoxy.Model.prototype.get.apply(this, arguments);
  }
});
```
I fully understand why in principle the modelMap should be a private variable - you don't want other people to mess with how the library works internally - but I think that it can be useful to have the opportunity to access it if one wants to extend Epoxy.